### PR TITLE
Add product detail page and detail navigation

### DIFF
--- a/app/composables/useFakeStore.ts
+++ b/app/composables/useFakeStore.ts
@@ -3,6 +3,29 @@ import type { FakeStoreProduct } from '~/types/fake-store'
 import { computed, toValue } from 'vue'
 import { fakeStoreProducts } from '../data/fakeStoreFallback'
 
+const EXTRA_PRODUCTS: FakeStoreProduct[] = [
+  {
+    id: 99999,
+    title: 'James the Orange Cat',
+    price: 999999.99,
+    description: `Bring home the elegance of sunshine with this radiant ginger tabby. With a coat that glows like autumn leaves and eyes full of gentle curiosity, this feline is the embodiment of comfort and grace. Whether perched by the window watching the world go by or curled up on your lap, this cat brings warmth, charm, and quiet companionship into any home.
+Perfect for those who appreciate beauty in simplicity, this lovely cat is affectionate yet independent—a loyal friend who loves both playtime and peaceful moments in the sun.`,
+    category: 'cats',
+    image: '/images/james.jpg',
+    rating: { rate: 5, count: 999999 },
+  },
+  {
+    id: 99998,
+    title: 'Nightmeow on Elm Street',
+    price: 49.99,
+    description: `This mischievous little furball is ready to claw its way into your nightmares—adorably, of course. Featuring a fiery orange tabby dressed in the iconic striped sweater, fedora, and razor-sharp claws, this design is a purr-fect mashup of horror and humor.
+Whether you’re a horror movie buff, a cat lover, or both, this tee will scratch that itch for quirky, spooky style. Soft, durable, and guaranteed to get laughs (and maybe a few uneasy stares), it’s a must-have for Halloween season or any day you want to unleash your inner nightmare.`,
+    category: 'cats',
+    image: '/images/kittykruger.webp',
+    rating: { rate: 4.9, count: 1234 },
+  },
+]
+
 const DEFAULT_BASE_URL = 'https://fakestoreapi.com'
 
 function resolveFallbackProducts(category: string | null) {
@@ -11,6 +34,20 @@ function resolveFallbackProducts(category: string | null) {
   }
 
   return fakeStoreProducts.filter(product => product.category === category)
+}
+
+function resolveFallbackProduct(id: number) {
+  const fromCatalog = fakeStoreProducts.find(product => product.id === id)
+  if (fromCatalog) {
+    return fromCatalog
+  }
+
+  const fromExtras = EXTRA_PRODUCTS.find(product => product.id === id)
+  if (fromExtras) {
+    return fromExtras
+  }
+
+  return null
 }
 
 function resolveFallbackCategories() {
@@ -62,37 +99,15 @@ export function useFakeStoreProducts(options: UseFakeStoreProductsOptions = {}) 
     },
   )
 
-  // A hardcoded product that should be visible to callers of useFakeStoreProducts.
-  // We append it to the fetched/fallback list. It will only be included when the
-  // current category filter matches the product's category (or when no category is set).
-  const james: FakeStoreProduct = {
-    id: 99999,
-    title: 'James the Orange Cat',
-    price: 999999.99,
-    description: `Bring home the elegance of sunshine with this radiant ginger tabby. With a coat that glows like autumn leaves and eyes full of gentle curiosity, this feline is the embodiment of comfort and grace. Whether perched by the window watching the world go by or curled up on your lap, this cat brings warmth, charm, and quiet companionship into any home.
-Perfect for those who appreciate beauty in simplicity, this lovely cat is affectionate yet independent—a loyal friend who loves both playtime and peaceful moments in the sun.`,
-    category: 'cats',
-    image: '/images/james.jpg',
-    rating: { rate: 5, count: 999999 },
-  }
-
-  const luna: FakeStoreProduct = {
-    id: 99998,
-    title: 'Nightmeow on Elm Street',
-    price: 49.99,
-    description: `This mischievous little furball is ready to claw its way into your nightmares—adorably, of course. Featuring a fiery orange tabby dressed in the iconic striped sweater, fedora, and razor-sharp claws, this design is a purr-fect mashup of horror and humor.
-Whether you’re a horror movie buff, a cat lover, or both, this tee will scratch that itch for quirky, spooky style. Soft, durable, and guaranteed to get laughs (and maybe a few uneasy stares), it’s a must-have for Halloween season or any day you want to unleash your inner nightmare.`,
-    category: 'cats',
-    image: '/images/kittykruger.webp',
-    rating: { rate: 4.9, count: 1234 },
-  }
-
   const productsWithExtra = computed(() => {
     const base = data.value ?? []
 
     // Respect category filter: if a specific category is selected and it doesn't
     // match the hardcoded products' category, return the base list unchanged.
-    if (normalizedCategory.value && normalizedCategory.value !== james.category) {
+    if (
+      normalizedCategory.value
+      && !EXTRA_PRODUCTS.some(product => product.category === normalizedCategory.value)
+    ) {
       return base
     }
 
@@ -101,17 +116,15 @@ Whether you’re a horror movie buff, a cat lover, or both, this tee will scratc
 
     const extras: FakeStoreProduct[] = []
 
-    const addCollisionSafe = (prod: FakeStoreProduct, offset: number) => {
+    EXTRA_PRODUCTS.forEach((prod, index) => {
+      const offset = index + 1
       if (base.some(p => p.id === prod.id) || extras.some(p => p.id === prod.id)) {
         extras.push({ ...prod, id: maxId + offset })
       }
       else {
-        extras.push(prod)
+        extras.push({ ...prod })
       }
-    }
-
-    addCollisionSafe(james, 1)
-    addCollisionSafe(luna, 2)
+    })
 
     // Place the hardcoded products first (in desired order) so they appear at the top of the product grid.
     return [...extras, ...base]
@@ -159,6 +172,64 @@ export function useFakeStoreCategories() {
 
   return {
     categories,
+    pending,
+    error,
+    refresh,
+  }
+}
+
+export function useFakeStoreProduct(id: MaybeRefOrGetter<number | string | null | undefined>) {
+  const runtimeConfig = useRuntimeConfig()
+  const baseURL = runtimeConfig.public.fakeStoreApiBase || DEFAULT_BASE_URL
+
+  const normalizedId = computed(() => {
+    const raw = toValue(id)
+
+    if (raw === null || raw === undefined) {
+      return null
+    }
+
+    const parsed = Number(raw)
+
+    if (Number.isNaN(parsed)) {
+      return null
+    }
+
+    return parsed
+  })
+
+  const key = computed(() =>
+    normalizedId.value !== null ? `fake-store-product-${normalizedId.value}` : 'fake-store-product-null',
+  )
+
+  const { data, pending, error, refresh } = useAsyncData<FakeStoreProduct | null>(
+    () => key.value,
+    async () => {
+      if (normalizedId.value === null) {
+        return null
+      }
+
+      try {
+        return await $fetch<FakeStoreProduct>(`${baseURL}/products/${normalizedId.value}`)
+      }
+      catch (fetchError) {
+        if (import.meta.env.DEV) {
+          console.warn('[FakeStore] Falling back to bundled product.', fetchError)
+        }
+
+        return resolveFallbackProduct(normalizedId.value)
+      }
+    },
+    {
+      default: () => null,
+      server: true,
+      lazy: false,
+      watch: [normalizedId],
+    },
+  )
+
+  return {
+    product: computed(() => data.value),
     pending,
     error,
     refresh,

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -125,7 +125,16 @@
           <p class="line-clamp-2 text-sm text-slate-500">
             {{ product.description }}
           </p>
-          <div class="mt-auto flex items-center justify-between gap-3">
+          <div class="mt-auto flex items-center gap-3">
+            <UButton
+              color="neutral"
+              variant="soft"
+              class="flex-1 justify-center transition-transform duration-150 ease-out focus-visible:ring-2 focus-visible:ring-primary-200 active:scale-95"
+              icon="i-heroicons-information-circle"
+              :to="`/products/${product.id}`"
+            >
+              View details
+            </UButton>
             <UButton
               color="primary"
               :loading="isAddingToCart(product.id)"

--- a/app/pages/products/[id].vue
+++ b/app/pages/products/[id].vue
@@ -1,0 +1,231 @@
+<template>
+  <section class="space-y-6">
+    <div class="flex flex-wrap items-center gap-3">
+      <UButton
+        color="neutral"
+        variant="ghost"
+        icon="i-heroicons-arrow-left-20-solid"
+        class="justify-start"
+        @click="handleGoBack"
+      >
+        Back
+      </UButton>
+      <div class="min-w-0 flex-1">
+        <UBreadcrumb :links="breadcrumbLinks" class="justify-end" />
+      </div>
+    </div>
+
+    <UAlert
+      v-if="productError"
+      color="error"
+      icon="i-heroicons-exclamation-circle"
+      title="We couldn’t load this product"
+      class="border border-error-200/70"
+    >
+      <template #description>
+        {{ productErrorMessage }}
+      </template>
+      <template #actions>
+        <UButton color="error" variant="solid" icon="i-heroicons-arrow-path" @click="refreshProduct">
+          Retry
+        </UButton>
+      </template>
+    </UAlert>
+
+    <UCard v-if="showSkeleton" class="border border-slate-200/80 bg-white/80 p-6">
+      <div class="flex flex-col gap-8 lg:flex-row">
+        <USkeleton class="aspect-square w-full max-w-xl rounded-3xl" />
+        <div class="flex flex-1 flex-col gap-6">
+          <USkeleton class="h-6 w-24 rounded-full" />
+          <USkeleton class="h-9 w-3/4 rounded-lg" />
+          <USkeleton class="h-6 w-1/3 rounded-lg" />
+          <USkeleton class="h-4 w-full rounded-md" />
+          <USkeleton class="h-4 w-11/12 rounded-md" />
+          <USkeleton class="h-4 w-2/3 rounded-md" />
+          <div class="mt-auto flex flex-wrap gap-3">
+            <USkeleton class="h-10 w-36 rounded-full" />
+          </div>
+        </div>
+      </div>
+    </UCard>
+
+    <UCard
+      v-else-if="product"
+      class="overflow-hidden border border-slate-200/80 bg-white/90 p-6 shadow-sm"
+    >
+      <div class="flex flex-col gap-8 lg:flex-row">
+        <div class="flex w-full justify-center lg:w-1/2">
+          <div class="relative aspect-[4/5] w-full max-w-xl overflow-hidden rounded-3xl bg-slate-100 p-6 shadow-inner shadow-slate-200">
+            <img
+              :src="product.image"
+              :alt="product.title"
+              class="h-full w-full object-contain"
+            >
+            <span class="absolute left-6 top-6 rounded-full bg-white/90 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm">
+              {{ categoryLabel }}
+            </span>
+          </div>
+        </div>
+        <div class="flex flex-1 flex-col gap-6">
+          <div class="space-y-3">
+            <h1 class="text-3xl font-semibold text-slate-900">{{ product.title }}</h1>
+            <p class="text-2xl font-medium text-primary-600">{{ priceFormatted }}</p>
+            <div class="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+              <span
+                v-if="ratingValue"
+                class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700"
+              >
+                <UIcon name="i-heroicons-star-20-solid" class="size-4" aria-hidden="true" />
+                {{ ratingValue }}
+                <span v-if="ratingCount" class="text-[11px] font-medium text-amber-600/80">
+                  ({{ ratingCount }})
+                </span>
+              </span>
+              <span class="inline-flex items-center gap-2 text-xs text-slate-500">
+                <UIcon name="i-heroicons-tag" class="size-4" aria-hidden="true" />
+                {{ categoryLabel }}
+              </span>
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <h2 class="text-base font-semibold text-slate-900">Product details</h2>
+            <p class="whitespace-pre-line text-sm leading-relaxed text-slate-600">
+              {{ product.description }}
+            </p>
+          </div>
+
+          <div class="mt-auto flex flex-wrap gap-3">
+            <UButton
+              color="primary"
+              :loading="isAddingToCart"
+              :disabled="isAddingToCart"
+              icon="i-heroicons-shopping-cart-20-solid"
+              class="min-w-40 justify-center transition-transform duration-150 ease-out focus-visible:ring-2 focus-visible:ring-primary-200 active:scale-95"
+              @click="handleAddToCart"
+            >
+              Add to cart
+            </UButton>
+          </div>
+        </div>
+      </div>
+    </UCard>
+
+    <UCard
+      v-else-if="showNotFound"
+      class="flex flex-col items-center gap-4 border border-dashed border-slate-200 bg-white/80 py-12 text-center"
+    >
+      <UIcon name="i-heroicons-question-mark-circle" class="size-12 text-slate-300" aria-hidden="true" />
+      <div class="space-y-1">
+        <h2 class="text-lg font-semibold text-slate-900">Product not found</h2>
+        <p class="max-w-md text-sm text-slate-500">
+          We couldn’t find a product with this identifier. It may have been removed or is temporarily unavailable.
+        </p>
+      </div>
+      <UButton color="neutral" variant="soft" icon="i-heroicons-arrow-left-20-solid" @click="handleGoBack">
+        Go back
+      </UButton>
+    </UCard>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { ComputedRef } from 'vue'
+import { useCartStore } from '~/stores/cart'
+
+const router = useRouter()
+const route = useRoute()
+
+const cartStore = useCartStore()
+const toast = useToast()
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+})
+
+const productId: ComputedRef<number | null> = computed(() => {
+  const raw = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id
+
+  if (!raw) {
+    return null
+  }
+
+  const parsed = Number(raw)
+  return Number.isNaN(parsed) ? null : parsed
+})
+
+const {
+  product,
+  pending: productPending,
+  error: productError,
+  refresh: refreshProduct,
+} = useFakeStoreProduct(productId)
+
+const priceFormatted = computed(() =>
+  product.value ? currencyFormatter.format(product.value.price) : '',
+)
+const ratingValue = computed(() =>
+  product.value?.rating?.rate ? product.value.rating.rate.toFixed(1) : null,
+)
+const ratingCount = computed(() => product.value?.rating?.count ?? null)
+
+function formatCategoryLabel(value: string) {
+  return value
+    .split(' ')
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+}
+
+const categoryLabel = computed(() =>
+  product.value ? formatCategoryLabel(product.value.category) : 'Unknown category',
+)
+
+const breadcrumbLinks = computed(() => [
+  { label: 'Home', to: '/' },
+  { label: product.value?.title ?? 'Product details', to: '#', active: true },
+])
+
+const showSkeleton = computed(() => productPending.value && !product.value)
+const showNotFound = computed(
+  () => !productPending.value && !product.value && !productError.value,
+)
+
+const productErrorMessage = computed(
+  () => productError.value?.message ?? 'Please check your connection and try again.',
+)
+
+const isAddingToCart = ref(false)
+
+function handleGoBack() {
+  if (import.meta.client && window.history.length > 1) {
+    router.back()
+    return
+  }
+
+  router.push('/')
+}
+
+function handleAddToCart() {
+  if (!product.value || isAddingToCart.value) {
+    return
+  }
+
+  isAddingToCart.value = true
+  const quantity = cartStore.addItem(product.value)
+
+  toast.add({
+    title: 'Added to cart',
+    description:
+      quantity > 1
+        ? `Updated quantity: ${quantity} × ${product.value.title}.`
+        : `${product.value.title} has been added to your cart.`,
+    icon: 'i-heroicons-shopping-cart-20-solid',
+  })
+
+  window.setTimeout(() => {
+    isAddingToCart.value = false
+  }, 400)
+}
+</script>


### PR DESCRIPTION
## Summary
- add a "View details" button to product cards and link to individual product pages
- expose shared extra product data and a single-product composable for detail fetching
- implement a styled product detail page with image, description, and cart/back actions

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e9b4ebbec08325ab2b9521632a3a17